### PR TITLE
Small Window tweaks to fit content

### DIFF
--- a/elecsus/elecsus_gui.py
+++ b/elecsus/elecsus_gui.py
@@ -255,7 +255,7 @@ class PlotSelectionPopUp(wx.PopupTransientWindow):
 
         win = wx.Panel(self)  # ,wx.ID_ANY,pos=(0,0),size=(180,200),style=0)
 
-        self.selection = wx.CheckListBox(win, wx.ID_ANY, choices=OutputPlotTypes, size=(150, -1))  # ,pos=(0,0))
+        self.selection = wx.CheckListBox(win, wx.ID_ANY, choices=OutputPlotTypes, size=(-1, -1))  # ,pos=(0,0))
         # self.win.Bind(wx.EVT_CHECKLISTBOX, self.OnTicked, self.selection)
         self.selection.Bind(wx.EVT_CHECKLISTBOX, self.OnTicked)
 
@@ -336,7 +336,7 @@ class PlotSelectionDialog(wx.Dialog):
 
         win = wx.Panel(self)  # ,wx.ID_ANY,pos=(0,0),size=(180,200),style=0)
 
-        self.selection = wx.CheckListBox(win, wx.ID_ANY, choices=OutputPlotTypes, size=(120, -1))  # ,pos=(0,0))
+        self.selection = wx.CheckListBox(win, wx.ID_ANY, choices=OutputPlotTypes, size=(-1, -1))  # ,pos=(0,0))
         # self.win.Bind(wx.EVT_CHECKLISTBOX, self.OnTicked, self.selection)
         self.selection.Bind(wx.EVT_CHECKLISTBOX, self.OnTicked)
 
@@ -1487,7 +1487,7 @@ class ElecSus_GUI_Frame(wx.Frame):
 
     def __init__(self, parent, title):
         """ Initialise main frame """
-        wx.Frame.__init__(self, None, title=title, size=(2000, 900))
+        wx.Frame.__init__(self, None, title=title, size=(1200, 500))
 
         ## EXPERIMENTAL
         # self._mgr = aui.AuiManager()
@@ -2918,7 +2918,7 @@ def start():
     app = wx.App(redirect=False)
     frame = ElecSus_GUI_Frame(None, "ElecSus GUI - General Magneto Optics")
 
-    frame.SetSize((1600, 900))
+    frame.SetSize((1200, 500)) # Not all of us have giant 1600 px monitors. 
     frame.Centre()
     frame.Show()
     app.MainLoop()


### PR DESCRIPTION
 #8 
My monitor apparently isn't as big as the authors... I had to keep on resizing the window just to close out of the program. I think there's probably a better way to choose the default size, but I think this is an improvement for now.  Also, some of the text in the plot fit options went over the bounds of the window, and the window didn't have a resizer. Setting the window size to -1 allowed for Auto-sizing appropriate for the content.